### PR TITLE
Fix news feed to show latest tech news instead of old data

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -171,10 +171,7 @@ export default function Index() {
     let aborted = false;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 1800);
-    Promise.all<[
-      LatestNewsItem[],
-      any[]
-    ]>([
+    Promise.all<[LatestNewsItem[], any[]]>([
       fetch("/api/news", { signal: controller.signal })
         .then(async (r) => (r.ok ? ((await r.json()) as LatestNewsItem[]) : []))
         .catch(() => []),
@@ -674,7 +671,8 @@ export default function Index() {
                 decoding={idx === 0 ? "sync" : "async"}
                 onError={(e) => {
                   (e.currentTarget as HTMLImageElement).onerror = null;
-                  (e.currentTarget as HTMLImageElement).src = "/placeholder.svg";
+                  (e.currentTarget as HTMLImageElement).src =
+                    "/placeholder.svg";
                 }}
               />
             );
@@ -701,7 +699,11 @@ export default function Index() {
                 className="rounded-2xl border border-primary/20 bg-transparent overflow-hidden glass-card"
               >
                 {readMoreUrl ? (
-                  <a href={readMoreUrl} target="_blank" rel="noopener noreferrer">
+                  <a
+                    href={readMoreUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     {imgEl}
                   </a>
                 ) : (

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -630,67 +630,90 @@ export default function Index() {
           </h2>
         </div>
         <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-6">
-          {newsItems.map((n: any, idx: number) => (
-            <article
-              key={n.id}
-              className="rounded-2xl border border-primary/20 bg-transparent overflow-hidden glass-card"
-            >
-              {(() => {
-                const builderFallback =
-                  "https://cdn.builder.io/api/v1/image/assets%2Fee358a6e64744467b38bd6a3468eaeb9%2F9aebb7e90f334acbb611405deeab415d?format=webp&width=1200&q=80";
-                const q4Href =
-                  "https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.livemint.com%2Fcompanies%2Fcompany-results%2Fq4-results-today-dmart-kotak-mahindra-idbi-bank-to-zen-tech-18-companies-to-declare-q4-results-2024-on-may-4-11714789780675.html&psig=AOvVaw0LKKs-2BIXMeJGos_tsuWA&ust=1759060848156000&source=images&cd=vfe&opi=89978449&ved=0CBUQjRxqFwoTCMCa3Mby-I8DFQAAAAAdAAAAABAL";
-                const isQ4 = n?.title?.toLowerCase().includes("q4 highlights");
-                const src =
-                  typeof n?.image === "string"
-                    ? n.image
-                    : n?.image?.id
-                      ? `/api/assets/${n.image.id}`
-                      : isQ4
-                        ? builderFallback
-                        : "/placeholder.svg";
-                const imgEl = (
-                  <img
-                    src={src}
-                    alt=""
-                    className="h-40 w-full object-cover border-b border-primary/10"
-                    loading={idx === 0 ? "eager" : "lazy"}
-                    decoding={idx === 0 ? "sync" : "async"}
-                    onError={(e) => {
-                      (e.currentTarget as HTMLImageElement).onerror = null;
-                      (e.currentTarget as HTMLImageElement).src =
-                        "/placeholder.svg";
-                    }}
-                  />
+          {newsItems.map((n: any, idx: number) => {
+            const builderFallback =
+              "https://cdn.builder.io/api/v1/image/assets%2Fee358a6e64744467b38bd6a3468eaeb9%2F9aebb7e90f334acbb611405deeab415d?format=webp&width=1200&q=80";
+            const q4Href =
+              "https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.livemint.com%2Fcompanies%2Fcompany-results%2Fq4-results-today-dmart-kotak-mahindra-idbi-bank-to-zen-tech-18-companies-to-declare-q4-results-2024-on-may-4-11714789780675.html&psig=AOvVaw0LKKs-2BIXMeJGos_tsuWA&ust=1759060848156000&source=images&cd=vfe&opi=89978449&ved=0CBUQjRxqFwoTCMCa3Mby-I8DFQAAAAAdAAAAABAL";
+            const isQ4 = n?.title?.toLowerCase().includes("q4 highlights");
+            const baseImage = n?.imageUrl ?? n?.image;
+            const src =
+              typeof baseImage === "string" && baseImage
+                ? baseImage
+                : baseImage?.id
+                  ? `/api/assets/${baseImage.id}`
+                  : isQ4
+                    ? builderFallback
+                    : "/placeholder.svg";
+
+            const imgEl = (
+              <img
+                src={src}
+                alt=""
+                className="h-40 w-full object-cover border-b border-primary/10"
+                loading={idx === 0 ? "eager" : "lazy"}
+                decoding={idx === 0 ? "sync" : "async"}
+                onError={(e) => {
+                  (e.currentTarget as HTMLImageElement).onerror = null;
+                  (e.currentTarget as HTMLImageElement).src = "/placeholder.svg";
+                }}
+              />
+            );
+
+            const readMoreUrl = n?.link ?? (isQ4 ? q4Href : null);
+            const metaBits: string[] = [];
+            if (n?.source) metaBits.push(n.source);
+            if (n?.publishedAt) {
+              const published = new Date(n.publishedAt);
+              if (!Number.isNaN(published.getTime())) {
+                metaBits.push(
+                  published.toLocaleDateString(undefined, {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  }),
                 );
-                return isQ4 ? (
-                  <a href={q4Href} target="_blank" rel="noopener noreferrer">
+              }
+            }
+
+            return (
+              <article
+                key={n.id}
+                className="rounded-2xl border border-primary/20 bg-transparent overflow-hidden glass-card"
+              >
+                {readMoreUrl ? (
+                  <a href={readMoreUrl} target="_blank" rel="noopener noreferrer">
                     {imgEl}
                   </a>
                 ) : (
                   imgEl
-                );
-              })()}
-              <div className="p-6">
-                <h3 className="font-semibold text-foreground">{n.title}</h3>
-                <p className="mt-2 text-sm text-foreground/90">{n.excerpt}</p>
-                {n?.link ? (
-                  <a
-                    href={n.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="mt-4 inline-block text-sm font-semibold text-foreground/90 hover:text-foreground"
-                  >
-                    Read more →
-                  </a>
-                ) : (
-                  <button className="mt-4 text-sm font-semibold text-foreground/90 hover:text-foreground">
-                    Read more →
-                  </button>
                 )}
-              </div>
-            </article>
-          ))}
+                <div className="p-6">
+                  <h3 className="font-semibold text-foreground">{n.title}</h3>
+                  {metaBits.length ? (
+                    <p className="mt-1 text-xs uppercase tracking-wide text-foreground/70">
+                      {metaBits.join(" • ")}
+                    </p>
+                  ) : null}
+                  <p className="mt-2 text-sm text-foreground/90">{n.excerpt}</p>
+                  {readMoreUrl ? (
+                    <a
+                      href={readMoreUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-4 inline-block text-sm font-semibold text-foreground/90 hover:text-foreground"
+                    >
+                      Read more →
+                    </a>
+                  ) : (
+                    <button className="mt-4 text-sm font-semibold text-foreground/90 hover:text-foreground">
+                      Read more →
+                    </button>
+                  )}
+                </div>
+              </article>
+            );
+          })}
         </div>
       </Section>
     </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -160,7 +160,7 @@ export default function Index() {
     },
   ];
 
-  const [newsItems, setNewsItems] = useState<any[]>(
+  const [newsItems, setNewsItems] = useState<LatestNewsItem[]>(
     news && news.length ? news : defaultNews,
   );
   const [testiItems, setTestiItems] = useState<any[]>(

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -171,12 +171,15 @@ export default function Index() {
     let aborted = false;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 1800);
-    Promise.all([
+    Promise.all<[
+      LatestNewsItem[],
+      any[]
+    ]>([
       fetch("/api/news", { signal: controller.signal })
-        .then((r) => (r.ok ? r.json() : ([] as any[])))
+        .then(async (r) => (r.ok ? ((await r.json()) as LatestNewsItem[]) : []))
         .catch(() => []),
       fetch("/api/testimonials", { signal: controller.signal })
-        .then((r) => (r.ok ? r.json() : ([] as any[])))
+        .then(async (r) => (r.ok ? ((await r.json()) as any[]) : []))
         .catch(() => []),
     ])
       .then(([n, t]) => {

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -14,6 +14,7 @@ import AnimatedTitle from "@/components/site/AnimatedTitle";
 import TiltCard from "@/components/site/TiltCard";
 import { Link, useLoaderData } from "react-router-dom";
 import { getIconByName } from "@/lib/iconMap";
+import type { LatestNewsItem } from "@shared/api";
 
 function AnimatedCounter({
   target,

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -99,17 +99,22 @@ export async function loader() {
 export default function Index() {
   const { sections, news, testimonials } = useLoaderData() as {
     sections: Record<string, any>;
-    news: any[];
+    news: LatestNewsItem[];
     testimonials: any[];
   };
 
-  const defaultNews = [
+  const defaultNews: LatestNewsItem[] = [
     {
       id: "s1",
       title: "Q4 Highlights",
       excerpt: "Milestones across platform and growth.",
       image:
         "https://cdn.builder.io/api/v1/image/assets%2Fee358a6e64744467b38bd6a3468eaeb9%2F9aebb7e90f334acbb611405deeab415d?format=webp&width=1200&q=80",
+      link: null,
+      source: null,
+      imageUrl: undefined,
+      publishedAt: null,
+      fetchedAt: null,
     },
     {
       id: "s2",
@@ -117,6 +122,11 @@ export default function Index() {
       excerpt: "We expanded to Berlin.",
       image:
         "https://images.unsplash.com/photo-1556761175-129418cb2dfe?auto=format&fit=crop&w=1200&q=80",
+      link: null,
+      source: null,
+      imageUrl: undefined,
+      publishedAt: null,
+      fetchedAt: null,
     },
     {
       id: "s3",
@@ -124,6 +134,11 @@ export default function Index() {
       excerpt: "We're hiring across the stack.",
       image:
         "https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80",
+      link: null,
+      source: null,
+      imageUrl: undefined,
+      publishedAt: null,
+      fetchedAt: null,
     },
   ];
   const defaultTestimonials = [

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,6 +61,18 @@ model News {
   enabled  Boolean @default(true)
 }
 
+model TechNews {
+  id          String   @id @default(cuid())
+  title       String
+  description String
+  url         String   @unique
+  imageUrl    String?
+  source      String?
+  publishedAt DateTime?
+  fetchedAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
 model Testimonial {
   id     String @id @default(cuid())
   author String

--- a/server/routes/public.ts
+++ b/server/routes/public.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { prisma } from "../prisma";
 import { memoryDb, serveAssetFallback } from "../dbFallback";
+import { getLatestTechNews } from "../services/techNews";
 
 const router = Router();
 
@@ -9,17 +10,65 @@ router.get("/news", async (_req, res) => {
     "Cache-Control",
     "public, max-age=30, stale-while-revalidate=60",
   );
+
   try {
-    const items = await prisma.news.findMany({
+    const techNews = await getLatestTechNews();
+    const serializedTechNews = techNews.map((item) => ({
+      id: item.id,
+      title: item.title,
+      excerpt: item.description,
+      link: item.url,
+      imageUrl: item.imageUrl,
+      source: item.source,
+      publishedAt: item.publishedAt,
+      fetchedAt: item.fetchedAt,
+    }));
+
+    if (serializedTechNews.length >= 3) {
+      return res.json(serializedTechNews.slice(0, 3));
+    }
+
+    const legacyItems = await prisma.news.findMany({
       orderBy: { date: "desc" },
       include: { image: true } as any,
+      take: 3,
     });
-    if (!items || items.length === 0) return res.json(memoryDb.news);
-    res.json(items);
-  } catch (e) {
-    console.warn("Prisma news failed, using memory store", e.message || e);
-    res.json(memoryDb.news);
+
+    const legacySerialized = legacyItems.map((item) => ({
+      id: item.id,
+      title: item.title,
+      excerpt: item.excerpt,
+      link: null,
+      image: item.image,
+      source: null,
+      publishedAt: item.date,
+      fetchedAt: item.date,
+    }));
+
+    const combined = [...serializedTechNews, ...legacySerialized].slice(0, 3);
+    if (combined.length === 3) {
+      return res.json(combined);
+    }
+
+    if (combined.length > 0) {
+      return res.json(combined);
+    }
+  } catch (error) {
+    console.warn("Latest tech news feed failed", error);
   }
+
+  const fallback = (memoryDb.news || []).slice(0, 3).map((item) => ({
+    id: item.id,
+    title: item.title,
+    excerpt: item.excerpt,
+    link: null,
+    image: item.image,
+    source: null,
+    publishedAt: item.date,
+    fetchedAt: item.date,
+  }));
+
+  res.json(fallback);
 });
 
 router.get("/testimonials", async (_req, res) => {

--- a/server/services/techNews.ts
+++ b/server/services/techNews.ts
@@ -1,0 +1,176 @@
+import { prisma } from "../prisma";
+
+const TECH_NEWS_ENDPOINT =
+  "https://techcrunch.com/wp-json/wp/v2/posts?per_page=6&_embed";
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+interface RawTechCrunchPost {
+  id?: number;
+  link?: string;
+  date?: string;
+  date_gmt?: string;
+  title?: { rendered?: string };
+  excerpt?: { rendered?: string };
+  yoast_head_json?: {
+    og_description?: string;
+    og_title?: string;
+    og_image?: { url?: string }[];
+  };
+  jetpack_featured_media_url?: string;
+  _embedded?: {
+    [key: string]: Array<{ source_url?: string; media_details?: any }>;
+  };
+}
+
+export interface NormalizedTechNewsItem {
+  id: string;
+  title: string;
+  description: string;
+  url: string;
+  imageUrl?: string | null;
+  source?: string | null;
+  publishedAt?: Date | null;
+  fetchedAt: Date;
+}
+
+function decodeEntities(input: string): string {
+  return input
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'");
+}
+
+function stripTags(input: string): string {
+  return decodeEntities(input.replace(/<[^>]*>/g, "").trim());
+}
+
+function extractImage(post: RawTechCrunchPost): string | undefined {
+  const fromYoast = post.yoast_head_json?.og_image?.[0]?.url;
+  if (fromYoast) return fromYoast;
+  if (post.jetpack_featured_media_url) return post.jetpack_featured_media_url;
+  const embedded = post._embedded?.["wp:featuredmedia"]?.[0];
+  if (embedded?.source_url) return embedded.source_url;
+  return undefined;
+}
+
+async function fetchExternalTechNews(): Promise<NormalizedTechNewsItem[]> {
+  const response = await fetch(TECH_NEWS_ENDPOINT, {
+    headers: { "User-Agent": "FusionStarterBot/1.0 (+https://builder.io)" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Tech news fetch failed: ${response.status}`);
+  }
+
+  const payload = (await response.json()) as RawTechCrunchPost[];
+  if (!Array.isArray(payload)) return [];
+
+  const now = new Date();
+
+  return payload
+    .map((post) => {
+      const link = typeof post.link === "string" ? post.link : undefined;
+      const rawTitle = post.title?.rendered ?? "";
+      const rawExcerpt =
+        post.yoast_head_json?.og_description ?? post.excerpt?.rendered ?? "";
+      if (!link || !rawTitle) return null;
+
+      const title = stripTags(rawTitle);
+      const description = stripTags(rawExcerpt || title);
+      const imageUrl = extractImage(post);
+      const publishedAt = post.date_gmt || post.date;
+
+      return {
+        id: `${post.id ?? link}`,
+        title,
+        description,
+        url: link,
+        imageUrl,
+        source: "TechCrunch",
+        publishedAt: publishedAt ? new Date(publishedAt) : null,
+        fetchedAt: now,
+      } satisfies NormalizedTechNewsItem;
+    })
+    .filter((item): item is NormalizedTechNewsItem => item !== null)
+    .slice(0, 6);
+}
+
+function mapRecordToNormalized(record: {
+  id: string;
+  title: string;
+  description: string;
+  url: string;
+  imageUrl: string | null;
+  source: string | null;
+  publishedAt: Date | null;
+  fetchedAt: Date;
+}): NormalizedTechNewsItem {
+  return {
+    id: record.id,
+    title: record.title,
+    description: record.description,
+    url: record.url,
+    imageUrl: record.imageUrl,
+    source: record.source,
+    publishedAt: record.publishedAt,
+    fetchedAt: record.fetchedAt,
+  };
+}
+
+export async function getLatestTechNews(): Promise<NormalizedTechNewsItem[]> {
+  const now = Date.now();
+  const staleCutoff = now - TWENTY_FOUR_HOURS_MS;
+
+  const existing = await prisma.techNews.findMany({
+    orderBy: { fetchedAt: "desc" },
+    take: 3,
+  });
+
+  if (
+    existing.length === 3 &&
+    existing.every((item) => item.fetchedAt.getTime() >= staleCutoff)
+  ) {
+    return existing.map(mapRecordToNormalized);
+  }
+
+  try {
+    const externalItems = await fetchExternalTechNews();
+    const topThree = externalItems.slice(0, 3);
+
+    if (topThree.length === 3) {
+      await prisma.$transaction([
+        prisma.techNews.deleteMany({}),
+        prisma.techNews.createMany({
+          data: topThree.map((item) => ({
+            title: item.title,
+            description: item.description,
+            url: item.url,
+            imageUrl: item.imageUrl ?? null,
+            source: item.source ?? null,
+            publishedAt: item.publishedAt ?? null,
+            fetchedAt: new Date(),
+          })),
+        }),
+      ]);
+
+      const refreshed = await prisma.techNews.findMany({
+        orderBy: { fetchedAt: "desc" },
+        take: 3,
+      });
+
+      if (refreshed.length === 3) {
+        return refreshed.map(mapRecordToNormalized);
+      }
+    }
+  } catch (error) {
+    console.warn("Failed to refresh tech news", error);
+  }
+
+  if (existing.length) {
+    return existing.map(mapRecordToNormalized);
+  }
+
+  return [];
+}

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -10,3 +10,15 @@
 export interface DemoResponse {
   message: string;
 }
+
+export interface LatestNewsItem {
+  id: string;
+  title: string;
+  excerpt: string;
+  link: string | null;
+  image?: unknown;
+  imageUrl?: string | null;
+  source?: string | null;
+  publishedAt?: string | Date | null;
+  fetchedAt?: string | Date | null;
+}


### PR DESCRIPTION
## Purpose

The user reported seeing old details in the latest news section. This change addresses the issue by implementing a proper tech news feed that fetches fresh content from external sources and displays current news items instead of stale data.

## Code changes

- **Added TechNews model** to Prisma schema for storing fetched news items
- **Created tech news service** (`techNews.ts`) that fetches from TechCrunch API with 24-hour caching
- **Updated news API endpoint** to prioritize fresh tech news over legacy static content
- **Enhanced news display** with proper TypeScript types (`LatestNewsItem`) and metadata (source, publish date)
- **Improved image handling** to support both legacy and new news item formats
- **Added fallback logic** to gracefully handle API failures and ensure news is always displayed

The news section now shows live tech news when available, with automatic fallback to existing content if external feeds fail.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b8e1946efb46415e9002e8e4adbf7e90/curry-world)

👀 [Preview Link](https://b8e1946efb46415e9002e8e4adbf7e90-curry-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b8e1946efb46415e9002e8e4adbf7e90</projectId>-->
<!--<branchName>curry-world</branchName>-->